### PR TITLE
fix🐛:  修改api接口pingti.xyz到pingti.app，并输出平替的理由

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export function apply(ctx: Context, config: Config) {
 
         try {
           const result = await ctx.http.post(
-            'https://www.pingti.xyz/api/chat',
+            'https://pingti.app/api/chat',
             JSON.stringify({
               messages: [
                 {
@@ -111,8 +111,10 @@ export function apply(ctx: Context, config: Config) {
 
       task = t.then(() => sleep(2000))
 
-      const result = (await t).toString('utf8')
-      if (result instanceof Error) throw result
+      const resultObj = await t;
+      if (resultObj instanceof Error) { throw resultObj };
+      const result = resultObj.response;
+      const reason = resultObj.reason;
 
       void ctx.database
         .upsert('pingti', [
@@ -126,7 +128,7 @@ export function apply(ctx: Context, config: Config) {
           l.error(e)
         })
 
-      return `${key} 的平替是：${result}`
+      return `${key} 的平替是：${result}\n理由：${reason}`;
     } catch (e) {
       l.error('处理时出现错误：')
       l.error(e)


### PR DESCRIPTION
resolves #1 
1、修改pingti.xyz的api接口为pingti.app （旧域名失效）
2、pingti.app现在会返回平替的理由，在插件中增加输出

自己调试的效果：
<img width="943" height="440" alt="image" src="https://github.com/user-attachments/assets/0958d94f-6b0f-4b1a-aaa1-0cbd0bef1603" />
